### PR TITLE
Uncaught TypeError: Argument 1 passed to CanalblogImporterImporterPost::saveMedias() must be of the type array, null given

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: php
 dist: xenial
 
 php:
-- '7.1'
-- '7.2'
+- '7.3'
 - '7.4'
 
 services:
@@ -14,8 +13,7 @@ cache:
   - $HOME/.composer/cache/files
 
 env:
-- WP_VERSION=5.0
-- WP_VERSION=5.2
+- WP_VERSION=5.3
 - WP_VERSION=5.4
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,22 @@
 language: php
+dist: xenial
 
 php:
 - '7.1'
 - '7.2'
+- '7.4'
 
 services:
 - mysql
 
-jobs:
-  fast_finish: true
+cache:
+  directories:
+  - $HOME/.composer/cache/files
 
 env:
 - WP_VERSION=5.0
 - WP_VERSION=5.2
-- WP_VERSION=5.3-RC2
+- WP_VERSION=5.4
 
 install:
 - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION

--- a/README.md
+++ b/README.md
@@ -59,15 +59,27 @@ Encore quelques clics et ça sera terminé !
 ## Développement
 
 ```bash
-brew install mariadb
-mysql.server start
-composer install
+# plugin (test) dependencies
+$ composer install
 
-sh bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.2
+# ephemeral database
+$ docker run --rm -p 3306:3306 -e MYSQL_ROOT_HOST=% -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_ROOT_PASSWORD='' mariadb:latest
+
+# setup a test WordPress instance
+$ sh bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.4
 ```
 
 ```bash
-composer run test
+$ composer run test
+> phpunit
+Installing...
+Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
+Not running ajax tests. To execute these, use --group ajax.
+Not running ms-files tests. To execute these, use --group ms-files.
+Not running external-http tests. To execute these, use --group external-http.
+PHPUnit 7.5.16 by Sebastian Bergmann and contributors.
+
+........E.F.....................................E......F....      60 / 60 (100%)
 ```
 
 ## Changelog ##

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ La classe !
 
 **Remarque**
 
-Cette extension nécessite au minimum `php@7.1`. Si vous avez un bon hébergeur,
+Cette extension nécessite au minimum `php@7.3`. Si vous avez un bon hébergeur,
 vous n'aurez même pas besoin d'y penser.
 Sinon vous verrez plein d'erreurs et rien ne fonctionnera.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Canalblog Importer [![Build Status](https://travis-ci.org/oncletom/wp-canalblog-importer.svg?branch=master)](https://travis-ci.org/oncletom/wp-canalblog-importer)
+# Canalblog Importer [![Build Status](https://travis-ci.com/oncletom/wp-canalblog-importer.svg?branch=master)](https://travis-ci.com/oncletom/wp-canalblog-importer)
 
 **Requires at least:** 5.0
-**Tested up to:** 5.3
+**Tested up to:** 5.4
 **Stable tag:** trunk
 
 > Fatigué(e) d'avoir à gérer un blog sur Canalblog ?

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -10,25 +10,86 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=/tmp/wordpress/
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
 
 set -ex
 
 install_wp() {
-	mkdir -p $WP_CORE_DIR
 
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
-	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
+	if [ -d $WP_CORE_DIR ]; then
+		return;
 	fi
 
-	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	mkdir -p $WP_CORE_DIR
 
-	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {
@@ -39,20 +100,33 @@ install_test_suite() {
 		local ioption='-i'
 	fi
 
-	# set up testing suite
-	mkdir -p $WP_TESTS_DIR
-	cd $WP_TESTS_DIR
-	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
 
-	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
-	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
-	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
-	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
-	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
-	sed $ioption "s|localhost|${DB_HOST}|" wp-tests-config.php
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
 }
 
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};
@@ -60,7 +134,7 @@ install_db() {
 	local EXTRA=""
 
 	if ! [ -z $DB_HOSTNAME ] ; then
-		if [[ "$DB_SOCK_OR_PORT" =~ ^[0-9]+$ ]] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
 		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
       "wordpress/wordpress-importer": "dev-trunk"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7"
     },
     "repositories": [
       {

--- a/lib/Importer/Post.class.php
+++ b/lib/Importer/Post.class.php
@@ -121,8 +121,11 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
     $dateResult = $xpath->query("//meta[@itemprop='url']");
     $timeResult = $xpath->query("//div[@itemtype='http://schema.org/Article']/div[@class='itemfooter']");
 
+    // old blogs have another metadata
     if (!$dateResult->length) {
-      return null;
+      $dateTimeResult = $xpath->query("//meta[@property='article:published_time']")->item(0)->getAttribute('content');
+
+      return str_replace('T', ' ', $dateTimeResult);
     }
 
     // http://xxx/archives/2013/09/02/27910679.html
@@ -140,7 +143,7 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
   }
 
   public function extractPostAuthorName($xpath) {
-    $result = $xpath->query("//*[@class='articlecreator' and @itemprop='creator']");
+    $result = $xpath->query("//*[@class='articlecreator' or @itemprop='creator']");
 
     if (!$result->length) {
       return 'admin';
@@ -154,8 +157,18 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
     $finder = new DomXpath($tmpDom);
 
     $result = $xpath->query("//div[@itemtype='http://schema.org/Article']")->item(0);
+    $strategy = 'article';
+
+    if (!$result) {
+      $result = $xpath->query("//div[@itemprop='articleBody']")->item(0);
+      $strategy = 'articleBody';
+    }
+
+    if (!$result) {
+      throw new CanalblogImporterException(sprintf(__("Failed to identify blog content. Please inform the plugin author about it.", 'canalblog-importer')));
+    }
+
     $result = $tmpDom->importNode($result, true);
-    $articleId = $result->getAttribute('id');
     $tmpDom->appendChild($result);
 
     // remove footer and everything after
@@ -192,30 +205,37 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
       $item->parentNode->removeChild($item);
     }
 
-    // remove titles
-    $anchor = $finder->query("//a[@name='". $articleId ."']")->item(0);
-    $parentNode = $anchor->parentNode;
+    // 'article' Strategy:
+    // we remove headlines because everything is mixed up
+    // this is the case with the 'article' Strategy (body is not clearly identifiable)
+    $articleId = $result->getAttribute('id');
 
-    while (true) {
-      $childNode = $parentNode->childNodes->item(0);
+    if ($articleId || $strategy === 'article') {
+      $anchor = $finder->query("//a[@name='". $articleId ."']")->item(0);
+      $parentNode = $anchor->parentNode;
 
-      // and we remove the next one as it's the real title
-      if ($childNode->isSameNode($anchor)) {
-        if ($parentNode->childNodes->item(1)->nodeName !== '#text') {
-          $parentNode->removeChild($parentNode->childNodes->item(1));
+      while (true) {
+        $childNode = $parentNode->childNodes->item(0);
+
+        // and we remove the next one as it's the real title
+        if ($childNode->isSameNode($anchor)) {
+          if ($parentNode->childNodes->item(1)->nodeName !== '#text') {
+            $parentNode->removeChild($parentNode->childNodes->item(1));
+          }
+          else {
+            $parentNode->removeChild($parentNode->childNodes->item(2));
+          }
+
+          break;
         }
         else {
-          $parentNode->removeChild($parentNode->childNodes->item(2));
+          $parentNode->removeChild($childNode);
         }
-
-        break;
-      }
-      else {
-        $parentNode->removeChild($childNode);
       }
     }
 
-    //remove attributes
+    // remove attributes
+    // it's ineffective with the 'articleBody' strategy
     $tmpDom->firstChild->removeAttribute('id');
     $tmpDom->firstChild->removeAttribute('itemscope');
     $tmpDom->firstChild->removeAttribute('itemtype');
@@ -242,7 +262,8 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
   public function extractComments($xpath) {
     $comments = array();
 
-    foreach ($xpath->query("//*[@itemprop='comment']") as $commentNode) {
+    // article and articleBody strategies
+    foreach ($xpath->query("//*[@itemprop='comment' or @class='comment_item']") as $commentNode) {
       if (!$commentNode->hasAttribute('data-cid')) {
         continue;
       }
@@ -394,6 +415,7 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
     $data['post_date'] = $this->extractPostDate($xpath);
 
     if (!$data['post_date']) {
+      var_dump($data);
       return $stats;
     }
 
@@ -455,7 +477,7 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
     }
     else
     {
-      $post_id = wp_insert_post($data);
+      $post_id = wp_insert_post($data, true);
       $data['ID'] = $post_id;
       $stats['status'] = __('imported', 'canalblog-importer');
     }

--- a/lib/Importer/Post.class.php
+++ b/lib/Importer/Post.class.php
@@ -729,9 +729,18 @@ class CanalblogImporterImporterPost extends CanalblogImporterImporterBase
         $postdata['post_title'] = '';
 
         $attachment_id = $wpImport->process_attachment($postdata, $original_uri);
-        add_post_meta($attachment_id, 'canalblog_attachment_uri', $original_uri, true);
-        $attachments[$uri] = array_merge($pair, array('id' => $attachment_id));
-        $stats['new']++;
+
+        if ($attachment_id instanceof WP_Error) {
+          $stats['error']++;
+          var_dump($attachment_id);
+          throw new CanalblogImporterException(sprintf(__("Failed to import a distant image.", 'canalblog-importer')));
+        }
+        else {
+          add_post_meta($attachment_id, 'canalblog_attachment_uri', $original_uri, true);
+          $attachments[$uri] = array_merge($pair, array('id' => $attachment_id));
+          $stats['new']++;
+        }
+
       }
 
     return $attachments;

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,7 @@ En bonus, si vous avez lié vos articles entre eux sur Canalblog, l'outil va cor
 
 **Remarque**
 
-Cette extension nécessite au minimum `php@7.1`. Si vous avez un bon hébergeur, vous n'aurez même pas besoin d'y penser.
+Cette extension nécessite au minimum `php@7.3`. Si vous avez un bon hébergeur, vous n'aurez même pas besoin d'y penser.
 Sinon vous verrez plein d'erreurs et rien ne fonctionnera.
 
 == Installation ==

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: oncletom
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=752034
 Tags: canalblog, wordpress, migration, import, admin, importer
 Requires at least: 5.0
-Tested up to: 5.3
+Tested up to: 5.4
 Stable tag: trunk
 
 

--- a/tests/fixtures/post-grisfluo.html
+++ b/tests/fixtures/post-grisfluo.html
@@ -1,0 +1,413 @@
+
+<!DOCTYPE html>
+<html xmlns:fb="http://www.facebook.com/2008/fbml" xmlns:og="http://ogp.me/ns#"><head>
+<title>Que rapporter de Lisbonne ? - gris fluo & green</title>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="content-language" content="fr" />
+<meta name="Description" content="Comment rentrer de Lisbonne sans rapporter quelques boîtes de sardines, maquereaux et autres poissons. Nous avons testé deux adresses. La..." />
+<meta name="Keywords" content="plantes, DIY, green, tuto, crochet, couture, tutoriel, bougies, tricot, jardin, bricolage, tuto deco, déco" />
+<meta name="generator" content="CanalBlog - http://www.canalblog.com" />
+<link rel="alternate" type="application/rss+xml" title="RSS" href="http://grisfluo.canalblog.com/rss.xml" />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.canalblog.com/cf/fe/rsd/?bid=1079270" />
+<link rel="stylesheet" href="http://grisfluo.canalblog.com/style/8/6/1651268/style.css" type="text/css" />
+<script>
+dataLayer = [{
+'Slots':'{"atf_rectangle_left_ad":"div-gpt-ad-82263","atf_rectangle_right_ad":"div-gpt-ad-40821","rectangle_atf":"div-gpt-ad-91020","header_ad":"div-gpt-ad-90550","sticky_footer_ad":"div-gpt-ad-85649","footer_ad":"div-gpt-ad-70371","slidein":"div-gpt-ad-95650"}',
+'isExplicit':'0',
+'isDev':'0',
+'isCDom':'0',
+'blogLang':'fr',
+'isMember':'0',
+'source':'CANALBLOG',
+'Zone':'BLOG',
+'CategoryId':'43',
+'PageSafe':'1',
+'BlogLastUpdate':'90',
+'StopSU':'1',
+'PageType':'message',
+'CategoryName':'Bricolage, D\u00E9co, Jardin',
+'BlogId':'1079270',
+'BlogUrl':'grisfluo',
+'DocumentId':'33097920',
+'DocumentCatName':'Balades en Europe',
+'DocumentTags':'',
+'CategoryGroupName':'Blog-Jardin-Bricolage'
+}];
+</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+{'gtm.start': new Date().getTime(),event:'gtm.js'}
+);var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm'+'.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PFBKWPW');
+</script>
+<!-- End Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+{'gtm.start': new Date().getTime(),event:'gtm.js'}
+);var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm'+'.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PXZQ89');
+</script>
+<!-- End Google Tag Manager -->
+<meta name="robots" content="max-snippet:-1,max-image-preview:large,max-video-preview:-1,index,follow" />
+<meta property="fb:app_id" content="116867175007475" />
+<meta property="fb:admins" content="717607561" />
+<meta property="og:title" content="Que rapporter de Lisbonne ? - gris fluo &amp; green" />
+<meta property="og:description" content="Comment rentrer de Lisbonne sans rapporter quelques bo&icirc;tes de sardines, maquereaux et autres poissons. Nous avons test&eacute; deux adresses. La..." />
+<meta property="og:image" content="https://p5.storage.canalblog.com/58/47/1079270/108154561.jpg" />
+<meta property="og:image:width" content="800" />
+<meta property="og:image:height" content="450" />
+<meta property="og:url" content="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html" />
+<meta property="og:type" content="article" />
+<meta property="article:published_time" content="2015-12-08T16:00" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:title" content="Que rapporter de Lisbonne ? - gris fluo &amp; green" />
+<meta name="twitter:description" content="Comment rentrer de Lisbonne sans rapporter quelques bo&icirc;tes de sardines, maquereaux et autres poissons. Nous avons test&eacute; deux adresses. La..." />
+<meta name="twitter:image:src" content="https://p5.storage.canalblog.com/58/47/1079270/108154561_q.jpg" />
+<link rel="image_src" href="https://p5.storage.canalblog.com/58/47/1079270/108154561.jpg" />
+<link rel="canonical" href="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html" />
+<meta name="google-site-verification" content="" />
+<meta name="msvalidate.01" content="" />
+<meta name="p:domain_verify" content=""91df61f34dbe665ef4d7e31a283c5da2"" />
+<script type="application/ld+json">
+{
+"@context": "schema.org",
+"@type": "NewsArticle",
+"headline": "Que rapporter de Lisbonne ?",
+"description": "Comment rentrer de Lisbonne sans rapporter quelques bo\u00EEtes de sardines, maquereaux et autres...",
+"mainEntityOfPage": {
+"@type": "WebPage",
+"@id": "http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html"
+},
+"datePublished": "2015-12-20T21:29",
+"dateModified": "2020-03-30T19:11",
+"author": {
+"@type": "Person",
+"name": "gris fluo"
+},
+"image": "https://p5.storage.canalblog.com/58/47/1079270/108154561.jpg",
+"publisher": {
+"@type": "Organization",
+"name": "gris fluo & green",
+"url": "http://grisfluo.canalblog.com/",
+"logo": {
+"@type": "ImageObject",
+"url": "https://static.canalblog.com/sharedDocs/images/frontend/logo.png",
+"width": 278,
+"height": 93
+}
+}
+}
+</script>
+<script type="text/javascript">
+var google_analytics_domain_name = '.canalblog.com';
+window.google_analytics_uacct = 'UA-12099278-1';
+</script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+<script type="text/javascript">
+var id = 1079270;
+var pid = 33097920;
+var meid = 0;
+</script>
+<script type="text/javascript">var CBVARS = {"is_mobile":false,"URLROOT":"https://www.canalblog.com","URLSROOT":"https://www.canalblog.com","STATICSERVER":"static.canalblog.com","ref_keyword":"","post_allow_comments":1,"is_logged":false,"blog_domain":"canalblog.com","blog_full_url":"http://grisfluo.canalblog.com/","blog_last_post_nb_day":"90","blog_id":1079270,"s":"zpuRjJLd0p6FwtKZmN7SjITe2J+B1dOYkpLOnYXY256C3w==","cat_id":43,"partner_name":"canalblog","blog_owner_member_id":100551,"widget_conf":{"rating":{"skin":"star","skin_wording":"%%i18n_you_like%%"},"sharebar":{"is_print":1,"is_email":1,"is_fb":1,"is_pin":1,"is_tw":0,"is_ln":0,"is_hc":0,"is_kd":0},"followbtn":{"pinterest":{"username":"grisfluo"},"twitter":{"username":""},"hc":{"username":""},"gp":{"username":"","type":"profile"},"fb":{"pageurl":"","width":"300","showfaces":"true","showstream":"false","showheader":"false"},"ig":{"username":"caroline_2n","size":"48"}},"extract":{"home":"1","archive":"1","align":"left","sticky":"1"},"profileimg":{"align":"right"},"menu":{"fixed":"1"},"tag":{"showPhotos":"1"},"column":{"fixed":1},"navigation":{"new":"1"},"newsletter":{"showCount":"0"},"seo":{"google":{"verif":""},"bing":{"verif":""},"pinterest":{"verif":"\"91df61f34dbe665ef4d7e31a283c5da2\""}}},"is_a":false};</script><script>window.twttr = (function(d, s, id) {
+var js, fjs = d.getElementsByTagName(s)[0],
+t = window.twttr || {};
+if (d.getElementById(id)) return t;
+js = d.createElement(s);
+js.id = id;
+js.src = "https://platform.twitter.com/widgets.js";
+fjs.parentNode.insertBefore(js, fjs);
+t._e = [];
+t.ready = function(f) {
+t._e.push(f);
+};
+return t;
+}(document, "script", "twitter-wjs"));</script><script type="text/javascript" src="https://static.canalblog.com/sharedDocs/js/blog/all-blog-min.js?1587033002"></script>
+<link rel="stylesheet" href="https://static.canalblog.com/sharedDocs/css/blog/all-blog-min.css?1587033002" media="screen" />
+<link rel="stylesheet" href="/sharedDocs/css/icomoon/style.css?1587033002" media="screen" />
+<script type="text/javascript">$(document).ready(function() {$("#content a:not('.no_lightbox'):has(img)").filter(function() {if($(this).attr('href')) return $(this).attr('href').toLowerCase().match(/\.(jpg|jpeg|png|gif|bmp)/);}).photosharebox(); initBxSlider();$(".navlinks a:not('.no_lightbox'):has(img)").filter(function() {if($(this).attr('href')) return $(this).attr('href').toLowerCase().match(/\.(jpg|jpeg|png|gif|bmp)/);}).photosharebox();$('.navlinks').fitVids({customSelector: "iframe[src^='http://www.dailymotion.com']"}); });</script>
+<script type="text/javascript">var _sf_startpt=(new Date()).getTime()</script><!--[if lt IE 9]>
+<script type="text/javascript" src="https://static.canalblog.com/sharedDocs/js/html5shiv.js"></script>
+<![endif]-->
+<!-- Début CanalBlog Stats -->
+<script type="text/javascript">
+$(document).ready(function() {
+$("body").on("click","a.postemailbut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'PostSuggest','eventLabel': 'Message'});});
+$("body").on("click","a.pageemailbut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'PostSuggest','eventLabel': 'Page'});});
+$("body").on("click","a.albumemailbut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'PostSuggest','eventLabel': 'Album'});});
+$("body").on("click","a.editpostbut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'EditPost','eventLabel': $(this).attr("href")});});
+$("body").on("click","a.editpagebut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'EditPage','eventLabel': $(this).attr("href")});});
+$("body").on("click",".edit_div img.delete_com_img", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'DeleteComment','eventLabel': 'frontend'});});
+$("body").on("click","a.editpalbumbut", function(){dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'EditAlbum','eventLabel': $(this).attr("href")});});
+$(".relatedlinks li a").click(function() {dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'related','eventLabel': $(this).attr("href"),'eventValue': $(this).closest("li").prevAll().length});});
+$("#cb_footer a").click(function() {dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'footer','eventLabel': $(this).text()});});
+$("#branding_bar a").on("click",function() {dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'topbar-link','eventLabel': $(this).text()});});
+$("#item_logo a").click(function(e) {dataLayer.push({'event': 'sendUAEvent','eventCategory': 'clickzone','eventAction': 'topbar-logo','eventLabel': 'logocb'});e.stopPropagation();});
+var display = "no";
+if ($("div#countercb").length) {
+display = "yes";
+}
+var i = new Image();
+t = "Que%20rapporter%20de%20Lisbonne%20%3F%20%2D%20gris%20fluo%20%26%20green";
+i.src = 'http://stats.canalblog.com/stats/?id=' + id + '&display=' + display + '&pid=' + pid + '&u=' + escape(document.location) + '&r=' + escape(document.referrer) + '&t=' + t + '&w=' + escape(screen.width) + '&java=1' + '&sc_random=' + Math.random();
+if ($("div#countercb").length) {
+$("div#countercb").html(i);
+}
+else {
+i.style.display = "none";
+$("body").append(i);
+}
+});
+</script>
+<!-- Fin CanalBlog Stats -->
+<script type='text/javascript'>
+var crtg_nid = '2929';
+var crtg_cookiename = 'crtg_rta';
+var crtg_varname = 'crtg_content';
+function crtg_getCookie(c_name){ var i,x,y,ARRCookies=document.cookie.split(";");for(i=0;i<ARRCookies.length;i++){x=ARRCookies[i].substr(0,ARRCookies[i].indexOf("="));y=ARRCookies[i].substr(ARRCookies[i].indexOf("=")+1);x=x.replace(/^\s+|\s+$/g,"");if(x==c_name){return unescape(y);} }return'';}
+var crtg_content = crtg_getCookie(crtg_cookiename);
+var crtg_rnd=Math.floor(Math.random()*99999999999);
+(function(){
+var crtg_url=location.protocol+'//rtax.criteo.com/delivery/rta/rta.js?netId='+escape(crtg_nid);
+crtg_url +='&cookieName='+escape(crtg_cookiename);
+crtg_url +='&rnd='+crtg_rnd;
+crtg_url +='&varName=' + escape(crtg_varname);
+var crtg_script=document.createElement('script');crtg_script.type='text/javascript';crtg_script.src=crtg_url;crtg_script.async=true;
+if(document.getElementsByTagName("head").length>0)document.getElementsByTagName("head")[0].appendChild(crtg_script);
+else if(document.getElementsByTagName("body").length>0)document.getElementsByTagName("body")[0].appendChild(crtg_script);
+})();
+</script><link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Dosis|Dancing Script" /><style type="text/css">
+		body { padding-top: 30px !important; }
+		#branding_bar{background:#F5F5F5; border-bottom:1px solid #BABABA;}
+		#branding_bar a:link{color:#999999;}
+		#branding_bar a:visited{color:#999999;}
+		#branding_bar a:hover{color:#6B6B6B;}
+		.item_left{padding:0 5px;}
+		#item_menu{}
+		#item_menu div{color:#999999;}
+		.item_right{padding:0 7px;}
+		.item_submenu{background-color:#F5F5F5; border-top:1px solid #BABABA; border-left:1px solid #BABABA;}
+		.item_submenulast{background-color:#F5F5F5; border-top:1px solid #BABABA; border-left:1px solid #BABABA; border-bottom:1px solid #BABABA;}
+		#item_close{}
+		#content img{max-width:100%;height:auto;}
+		#comment_list img {max-width:none;}
+		#blogsugitem {}
+		</style><script type="text/javascript">hostName = '.canalblog.com'; setCookie('key','941664200D1D43C74B04CAB34DE428CA');</script><style type="text/css">div.error-form-comment {font-weight:bold;} input.error-form-comment,textarea.error-form-comment {border:2px solid red;}</style></head>
+<body>
+<div id="fb-root"></div>
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/fr_FR/sdk.js#xfbml=1&version=v3.2&appId=116867175007475&autoLogAppEvents=1"></script>
+<div id="branding_bar" style="display:block;"><ul id="topnav"><li id="item_logo"><a href="https://www.canalblog.com" onClick="javascript:window.open(this.href);return false;"><img src="https://static.canalblog.com/sharedDocs/images/bb-canalblog2.png" style="width:84px; margin:10px 0 0 0;" /></a></li><li id="item_form">
+<form action="https://www.canalblog.com/cf/search.cfm" method="get" target="_blank">
+<input type="text" id="q" name="q" class="text" placeholder="Rechercher.." value="" style="float:left;" />
+<input type="hidden" value="1079270" name="bid" />
+<input type="hidden" value="Rechercher" name="searchBtn" />
+<button type="submit"><span class="icon-search"></span></button>
+<input type="hidden" id="s" name="s" value="0FFFF1778CFFD310BFF77B95DEE52D32" /></form>
+</li><li class="item_left"><span><a href="https://www.canalblog.com/cf/contactAuthor.cfm?mid=100551&bid=1079270" onClick="javascript:window.open(this.href);return false;" rel="nofollow">Contacter l'auteur</a></span></li><li id="blogsugitem" class="item_left"><a href="https://www.canalblog.com/cf/blogsuggest.cfm?bid=1079270" class="cboxpopup" rel="nofollow">Envoyer à un ami</a></li><li style="display:none;" class="item_left item_cb_subscribe"><a href="#" class="item_cb_subscribe_link"><img src="https://static.canalblog.com/sharedDocs/images/cb_plane.png" class="item_cb_subscribe_img"><span class="item_cb_subscribe_text">S'abonner</span></a></li><li id="item_share"></li><li id="item_close" ><span class="icon-circle-up"></span></li><li id="item_menu" style="display:none;"></li><li id="item_menu_2" class="item_right" style="display:none;"></li><li id="item_menu_3" class="item_right" style="display:none;"></li></ul></div><div id="branding_bar_closed" style="display:none;"><ul id="topnav_closed"><li id="item_open" ><span class="icon-circle-down"></span></li></ul></div><div style='text-align:center;margin-bottom:8px;'><div id="div-gpt-ad-90550">
+</div>
+</div><div id="container"><div id="topbar-logo"><div class="logolink"><a href="http://grisfluo.canalblog.com/"></a></div></div><div id="topbar"><div id="topbar-title"><a href="http://grisfluo.canalblog.com/">gris fluo & green</a></div></div>
+<div id="leftbar"> <div class="navlinks">
+<div class="item">
+<script type="text/javascript">
+<!--
+document.write('<a href="https://www.canalblog.com/cf/contactAuthor.cfm?mid=100551&amp;bid=1079270">Contactez l\'auteur</a>'); // -->
+</script>
+</div><div style="padding:10px 0px 10px 0px;text-align:center;"><div id="div-gpt-ad-91020">
+</div>
+</div>
+<style>.ig-b- { display: inline-block; }
+.ig-b- img { visibility: hidden; }
+.ig-b-:hover { background-position: 0 -60px; } .ig-b-:active { background-position: 0 -120px; }
+.ig-b-48 { width: 48px; height: 48px; background: url(//badges.instagram.com/static/images/ig-badge-sprite-48.png) no-repeat 0 0; }
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (-o-min-device-pixel-ratio: 2 / 1), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+.ig-b-48 { background-image: url(//badges.instagram.com/static/images/ig-badge-sprite-48@2x.png); background-size: 60px 178px; } }</style>
+<a href="http://instagram.com/caroline_2n?ref=badge" class="ig-b- ig-b-48"><img src="//badges.instagram.com/static/images/ig-badge-48.png" alt="Instagram" /></a>
+<aside class="follow_btn">
+<a data-pin-do="buttonFollow" href="http://www.pinterest.com/grisfluo/">Suivre grisfluo</a>
+</aside>
+<div class="title">Newsletter</div><form name="newsletter" id="newsletter" action="https://www.canalblog.com/cf/blogsubscribe.cfm?bid=1079270" method="post" target="_blank">
+<input name="email" id="email" value="email" type="text" onfocus="this.select();" />
+<input name="submit" value="M'abonner" type="submit" />
+<input type="hidden" id="s" name="s" value="0FFFF1778CFFD310BFF77B95DEE52D32" /></form><div class="title">Cat&eacute;gories</div>
+<ul>
+<li><a href="http://grisfluo.canalblog.com/archives/balades_en_europe/index.html">Balades en Europe</a></li>
+<li><a href="http://grisfluo.canalblog.com/archives/balades_en_france/index.html">Balades en France</a></li>
+<li><a href="http://grisfluo.canalblog.com/archives/balades_en_occitanie/index.html">Balades en Occitanie</a></li>
+<li><a href="http://grisfluo.canalblog.com/archives/diy_et_tutoriels/index.html">DIY et tutoriels</a></li>
+<li><a href="http://grisfluo.canalblog.com/archives/histoires_de_plantes/index.html">Histoires de plantes</a></li>
+<li><a href="http://grisfluo.canalblog.com/archives/parcs_et_jardins_botaniques/index.html">Parcs et jardins botaniques</a></li>
+</ul>
+<div class="item"><a href="http://grisfluo.canalblog.com/rss.xml" title="S'abonner à ce blog (messages)"><img class="bullet" width="14" height="14" src="https://static.canalblog.com/sharedDocs/images/rss.png" alt="RSS" /></a><a href="http://grisfluo.canalblog.com/rss.xml" title="S'abonner à ce blog (messages)">Flux RSS des messages</a></div>
+<div class="item"><a href="http://grisfluo.canalblog.com/feeds/rss/comments/" title="S'abonner à ce blog (messages)"><img class="bullet" width="14" height="14" src="https://static.canalblog.com/sharedDocs/images/rss.png" alt="RSS" /></a><a href="http://grisfluo.canalblog.com/feeds/rss/comments/" title="S'abonner à ce blog (commentaires)">Flux RSS des commentaires</a></div>
+</div></div><div id="content"><div class="blogbody"><div class="breadcrumb"><div><a href="http://grisfluo.canalblog.com/"><span>gris fluo & green</span></a></div> &gt; <div><a href="http://grisfluo.canalblog.com/archives/balades_en_europe/index.html"><span>Balades en Europe</span></a></div> &gt; <div><h1 style="display:inline;font-size:x-small;font-weight:normal;">Que rapporter de Lisbonne ?</h1></div></div>
+<div id="33097920" class="item_div" data-edittype="post"><!-- post "33097920"-->
+<div class="dateheader">08 décembre 2015</div>
+<a name="33097920"></a>
+<h2 class="articletitle"><a href="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html" title="Que rapporter de Lisbonne ?" rel="bookmark">Que rapporter de Lisbonne ?</a></h2>
+<div class="articlebody" itemprop="articleBody"><p>Comment rentrer de Lisbonne sans rapporter quelques boîtes de sardines, maquereaux et autres poissons. Nous avons testé deux adresses.</p>
+<p>La première, Loja da conservas (rua do Arsonal, 30) qui vous propose une très large gamme de conserves de poissons.( des conserves Bio, millésimées , des rillettes et oeufs de poisson etc...)</p>
+<p>On&nbsp;a envie de tout acheter tellement les packaging sont sympas. On a même craqué pour une boîte de caviar de sardine testé et approuvé en famille à Noël.&nbsp;</p>
+<p style="text-align: center;"><a name="IMG_108154435" href="https://p8.storage.canalblog.com/89/32/1079270/108154435_o.jpg" target="_blank"><img src="https://p8.storage.canalblog.com/89/32/1079270/108154435.jpg" border="0" alt="image" class="width450 nonealign" /></a></p>
+<p style="text-align: center;"><a name="IMG_108154457" href="https://p5.storage.canalblog.com/59/40/1079270/108154457_o.jpg" target="_blank"><img src="https://p5.storage.canalblog.com/59/40/1079270/108154457.jpg" border="0" alt="image" class="width450 centeralign" /></a>&nbsp;</p>
+<p style="text-align: center;"><span>Pour les plus pressés, il y a même un distributeur automatique !</span></p>
+<p style="text-align: center;">&nbsp;<a name="IMG_108154561" href="https://p5.storage.canalblog.com/58/47/1079270/108154561_o.jpg" target="_blank"><img src="https://p5.storage.canalblog.com/58/47/1079270/108154561.jpg" border="0" alt="image" class="width450 centeralign" /></a></p>
+<p style="text-align: center;">&nbsp;&nbsp;Nous nous sommes rendus également dans la plus vieille conserverie de Lisbonne, elle date de 1930 et est située &nbsp;rua dos &nbsp;<span>Bacalhoeiros.&nbsp;</span>C'est une toute petite échoppe au charme désuet, les étagères et les vitrines sont en bois, de vielles plaques émaillées et une ancienne caisse enregistreuse en font un lieu très vintage ! Le petit moins, lorsque nous y sommes allés, l'accueil a été très moyen, c'était peut être un jour "sans"!&nbsp;</p>
+<p style="text-align: center;"><a name="IMG_108200496" href="https://p3.storage.canalblog.com/36/04/1079270/108200496_o.jpg" target="_blank"><img src="https://p3.storage.canalblog.com/36/04/1079270/108200496.jpg" border="0" alt="image" class="width450 centeralign" /></a></p>
+<p style="text-align: center;"><a name="IMG_108200518" href="https://p6.storage.canalblog.com/62/93/1079270/108200518_o.jpeg" target="_blank"><img src="https://p6.storage.canalblog.com/62/93/1079270/108200518.jpeg" border="0" alt="image" class="width450 centeralign" /></a>I</p>
+<p style="text-align: center;">&nbsp;</p>
+<p style="text-align: center;"><a name="IMG_108200643" href="https://p1.storage.canalblog.com/18/06/1079270/108200643_o.jpeg" target="_blank"><img src="https://p1.storage.canalblog.com/18/06/1079270/108200643.jpeg" border="0" alt="image" class="width450 centeralign" /></a></p>
+<p style="text-align: center;"><a name="IMG_108200659" href="https://p5.storage.canalblog.com/57/20/1079270/108200659_o.jpeg" target="_blank"><img src="https://p5.storage.canalblog.com/57/20/1079270/108200659.jpeg" border="0" alt="image" class="width450 centeralign" /></a></p>
+<p style="text-align: center;">&nbsp;</p>
+<p style="text-align: center;"><a name="IMG_108200625" href="http://p9.storage.canalblog.com/95/54/1079270/108200625_o.jpeg" target="_blank"><img src="http://p9.storage.canalblog.com/95/54/1079270/108200625.jpeg" border="0" alt="image" class="width450 centeralign" /></a></p><div style='clear:both;'></div></div>
+<div class="itemfooter">Posté par : <span class='articlecreator'>gris fluo</span> à <span class="articledate">16:00</span> - <a href="http://grisfluo.canalblog.com/archives/balades_en_europe/index.html" title="Autres messages dans cette catégorie" rel="tag">Balades en Europe</a> - <a href="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html#comments" title="Tous les commentaires sur Que rapporter de Lisbonne ?">Commentaires [2]</a> - Permalien [<a href="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html" rel="bookmark" title="Que rapporter de Lisbonne ?">#</a>]
+<br /><div class="share_widget" data-sharemediaurl="https://p5.storage.canalblog.com/58/47/1079270/108154561_q.jpg" data-sharetype="post" data-shareemailcount="0" data-shareid="33097920" data-sharelink="http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html" data-sharesummary="Que%20rapporter%20de%20Lisbonne%20%3F"></div><br />
+</div>
+<div id='blognavigationnew'><ul class='nt-list-nav'><li id='prevarticleli'><div class='nt-nav nav-style'><a class='prevnav' rel='prev' href='http://grisfluo.canalblog.com/archives/2015/04/28/31969111.html' title="Voir l'article: Cuisiner les fleurs de capucines"><img src='https://p3.storage.canalblog.com/35/84/1079270/103790951.jpg' /></a></div><div class='nt-title'><div class='slider-container'><div class='ib-dt'><a href='http://grisfluo.canalblog.com/archives/2015/04/28/31969111.html' title="Voir l'article: Cuisiner les fleurs de capucines" class='ib-inner'><em>Article précédent (28/04/2015)</em><p>CUISINER LES FLEURS DE CAPUCINES</p></a></div><div class='ib-tm'><a class='ib-inner' href='http://grisfluo.canalblog.com/archives/2015/04/28/31969111.html' title="Voir l'article: Cuisiner les fleurs de capucines"><p>Après une récolte au jardin ce matin, opération gelée de fleurs de capucines ! La cagette représente 160gr de...<br/><br/><em>&raquo; Lire la suite</em></p></a></div></div></div></li><li id='nextarticleli'><div class='nt-nav nav-style'><a class='nextnav' rel='next' href='http://grisfluo.canalblog.com/archives/2016/01/03/33097832.html' title="Voir l'article: Roof top bar à Lisbonne"><img src='https://p8.storage.canalblog.com/87/46/1079270/108153753.jpg' /></a></div><div class='nt-title'><div class='slider-container'><div class='ib-dt'><a href='http://grisfluo.canalblog.com/archives/2016/01/03/33097832.html' title="Voir l'article: Roof top bar à Lisbonne" class='ib-inner'><em>Article suivant (03/01/2016)</em><p>ROOF TOP BAR À LISBONNE</p></a></div><div class='ib-tm'><a class='ib-inner' href='http://grisfluo.canalblog.com/archives/2016/01/03/33097832.html' title="Voir l'article: Roof top bar à Lisbonne"><p>Avant les fêtes de Noël , je suis allée passer quelques jours à Lisbonne, une ville géniale, très accueillante...<br/><br/><em>&raquo; Lire la suite</em></p></a></div></div></div></li></ul><div style='clear:both'></div></div>
+<div class="relatedlinks">
+<div class="title">Vous aimerez peut-être :</div>
+<ul id="relatedpostslist" class="relatedpostslist">
+<li><a href="http://grisfluo.canalblog.com/archives/2019/08/31/37595378.html"><img src="https://p9.storage.canalblog.com/97/66/1079270/124520632_q.jpeg" alt="Édimbourg en 5 articles" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2019/08/31/37595378.html">Édimbourg en 5 articles</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2019/08/27/37590876.html"><img src="https://p8.storage.canalblog.com/86/19/1079270/124514954_q.jpg" alt="Sortie en bateau à proximité d’edimbourg" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2019/08/27/37590876.html">Sortie en bateau à proximité d’edimbourg</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2017/11/04/35833489.html"><img src="https://p3.storage.canalblog.com/35/25/1079270/117988239_q.jpg" alt="Prague #3# 3 adresses pour prendre un en-cas" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2017/11/04/35833489.html">Prague #3# 3 adresses pour prendre un en-cas</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2017/11/06/35833552.html"><img src="https://p1.storage.canalblog.com/21/47/1079270/117988438_q.jpg" alt="Prague #4# street art et sculpture" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2017/11/06/35833552.html">Prague #4# street art et sculpture</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2017/11/03/35833408.html"><img src="https://p1.storage.canalblog.com/23/74/1079270/117987799_q.jpg" alt="Prague #2# shopping et découvertes fleuries" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2017/11/03/35833408.html">Prague #2# shopping et découvertes fleuries</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2017/11/03/35832896.html"><img src="https://p1.storage.canalblog.com/16/38/1079270/117987263_q.jpg" alt="Prague #1# shopping" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2017/11/03/35832896.html">Prague #1# shopping</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2016/11/07/34483602.html"><img src="https://p1.storage.canalblog.com/25/76/1079270/113132625_q.jpg" alt="Le musée blau de barcelone" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2016/11/07/34483602.html">Le musée blau de barcelone</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2016/01/12/33106532.html"><img src="https://p9.storage.canalblog.com/99/91/1079270/108187408_q.jpeg" alt=" lx factory à lisbonne " /></a> <div><a href="http://grisfluo.canalblog.com/archives/2016/01/12/33106532.html"> lx factory à lisbonne </a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2016/01/09/33098157.html"><img src="https://p9.storage.canalblog.com/99/90/1079270/108155224_q.jpg" alt="Street arts à lisbonne" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2016/01/09/33098157.html">Street arts à lisbonne</a></div></li>
+<li><a href="http://grisfluo.canalblog.com/archives/2016/01/03/33097832.html"><img src="https://p8.storage.canalblog.com/87/46/1079270/108153753_q.jpg" alt="Roof top bar à lisbonne" /></a> <div><a href="http://grisfluo.canalblog.com/archives/2016/01/03/33097832.html">Roof top bar à lisbonne</a></div></li>
+</ul>
+<div style="clear:both;"></div>
+</div>
+</div><div id="taboola-below-article-thumbnails"></div><div id='cbinsideads'><div style='float:left;'><div id="div-gpt-ad-82263">
+</div>
+</div><div style='float:right;'><div id="div-gpt-ad-40821">
+</div>
+</div></div><div style='clear:both;'></div><br />
+<h3><a id="comments"></a>Commentaires sur Que rapporter de Lisbonne ?</h3>
+<ul id="comment_list" class="comment_thread level-1"><li class="comment guest level-1"><div class="comment_item" id="comment_68343351" data-edittype="post" data-cid="68343351" data-pid="33097920" data-mid="0"><a id="c68343351"></a>
+<p><div class="pp-container"><img class="gravatar" src="http://www.gravatar.com/avatar/db9fca1c055bea6a3782ce7299fec81c?s=40&d=https%3A%2F%2Fstatic%2Ecanalblog%2Ecom%2FsharedDocs%2Fimages%2Ffrontend%2Fdefault%5Fpp%2Epng" /></div> Je crois qu'il me reste une boite de mon dernier WE à Lisbonne il y a … deux ans !</p>
+<div class="itemfooter">Posté par <a href="http://www.feedesbrumes.com/" rel="nofollow" title="http://www.feedesbrumes.com/" target="_blank">Fée des Brumes</a>, <abbr class="timeago" title="2016-01-19T22:46:28">19 janvier 2016 à 22:46</abbr> | <span id="rating_w_68343351" class="comment_rating" data-commentid="68343351" data-raters="" data-rating="0" href="" data-key="g9fRmIbc152E39WVh9jS"></span> | <span class="comment_reply"><a rel="nofollow" href="#">Répondre</a></span></div>
+</div></li><li><ul class="comment_thread"><li class="comment post-owner member level-2"><div class="comment_item" id="comment_68343531" data-edittype="post" data-cid="68343531" data-pid="33097920" data-mid="0"><a id="c68343531"></a>
+<p><div class="pp-container"><a class="profile_link" onclick="window.open(this.href); return false;" href="https://www.canalblog.com/cf/profile.cfm?mid=100551"><img class="gravatar" src="https://profilepics.canalblog.com/profilepics/1/0/100551.jpg" /></a></div> Elles bonifient avec le temps .... Il suffit de les tourner de temps à autre ....</p>
+<div class="itemfooter">Posté par <a href="http://grisfluo.canalblog.com" title="http://grisfluo.canalblog.com" onclick="window.open(this.href); return false;">gris fluo</a>, <abbr class="timeago" title="2016-01-19T23:09:02">19 janvier 2016 à 23:09</abbr> | <span id="rating_w_68343531" class="comment_rating" data-commentid="68343531" data-raters="" data-rating="0" href="" data-key="g9fRmIba0Z2E39WVh9jS"></span> | <span class="comment_reply"><a rel="nofollow" href="#">Répondre</a></span></div>
+</div></li></ul></li></ul><div>
+</div> <!--
+<p></p>
+-->
+<div id="origFrmComment">
+<div class="commentheader">Nouveau commentaire</div>
+<form action="" method="post" name="frmComment" id="frmComment">
+<div id="cancel_reply_comment"><a rel="nofollow" class="cancel_reply_comment_lnk" href="http://grisfluo.canalblog.com/archives/2016/04/04/33616122.html">Annuler la réponse</a></div>
+<div>
+<textarea id="commentBody" name="commentBody" placeholder="Entrez votre commentaire"></textarea>
+</div>
+<div id="comment_service_list" style="display:none;" class="cb_guest">
+Commenter avec
+<a rel="nofollow" class="cowith" href="https://www.canalblog.com/cf/loginbox.cfm"><img src="https://static.canalblog.com/sharedDocs/images/comment_with_cb.png" width="20" height="20" border="0" />CanalBlog</a> |
+Utiliser <a rel="nofollow" href="https://www.facebook.com/dialog/oauth/?client_id=116867175007475&scope=email&display=popup&redirect_uri=https%3A%2F%2Fwww%2Ecanalblog%2Ecom%2Fcf%2Ffe%2Fremote%2Ffacebook%2Ecfm%3Fredirect%3Dtrue" class="cowith"><img src="https://static.canalblog.com/sharedDocs/images/comment_with_fb.png" width="20" height="20" border="0" />Facebook</a>
+</div>
+<div id="comment_logued_as" style="display:none;"><span id="comment_logued_as_username"></span>
+<a rel="nofollow" class="cb_logout" href="https://www.canalblog.com/cf/SessionController.cfc?method=logout">Se déconnecter</a>
+</div>
+<div id="comment_error_container"></div>
+<div id="comment_guest_fields" style="display:none;" class="cb_guest">
+OU
+<div><input id="authorNickName" name="authorNickName" value="" maxlength="16" placeholder="* Nom ou pseudo" /></div>
+<div><input id="authorEmail" name="authorEmail" value="" maxlength="64" placeholder="Votre email" /></div>
+<div><input id="authorWebsiteUrl" name="authorWebsiteUrl" value="" maxlength="128" placeholder="Site Web" /></div>
+<div id="comment_conditions">* Champs obligatoires. Adresse email visible uniquement par l'auteur du blog.</div>
+</div>
+<div id="comment_options">
+<label>
+<input checked="checked" type="checkbox" id="receiveAlert" name="receiveAlert" value="1" />
+Recevoir un email lorsqu'un commentaire est publié sur ce message.</label>
+</div>
+<input type="hidden" name="commentIdentity" id="commentIdentity" value="guest" />
+<input type="hidden" name="commentParentId" id="commentParentId" value="" />
+<div id="rememberInfo_field">
+<button class="comment_submit" type="submit">Publier</button>
+</div>
+<input type="hidden" id="s" name="s" value="0FFFF1778CFFD310BFF77B95DEE52D32" /></form>
+</div>
+</div></div><div class="clear">&nbsp;</div></div><script type="text/javascript">$(document).ready(function() {var color = new RGBColor($('body').css('background-color'));var rgb = color.toRGB();var re = /rgb\((\d+), (\d+), (\d+)\)/;rgb = re.exec(rgb);var r = parseInt(rgb[1], 10),g = parseInt(rgb[2], 10),b = parseInt(rgb[3], 10);var brightness = (r*299 + g*587 + b*114) / 1000;if (brightness > 125) {$('#cb_footer,#cb_footer a').css('color','#000000');} else {$('#cb_footer,#cb_footer a').css('color','#FFFFFF');}});</script><div id="cb_footer" style="font: 11px Arial;text-align:center;margin:5em 0em 1em 0em"><a style="color:black;text-decoration:underline;" href="https://www.canalblog.com">Blog hébergé par CanalBlog</a> | <a style="color:black;text-decoration:underline;" href="https://www.canalblog.com/cf/legalnotice.cfm" onclick="javascript:window.open(this.href);return false;">Mentions légales</a> | <a style="color:black;text-decoration:underline;" href="http://grisfluo.canalblog.com/archives/index.html" title="Plan du site gris fluo & green">Plan du site</a> | <a style="color:black;text-decoration:underline;" href="https://www.canalblog.com/directory/Bricolage, Déco, Jardin/">Blog Bricolage, Déco, Jardin</a> <a style="color:black;text-decoration:underline;" href='https://www.canalblog.com/birthday/Bricolage%2C%20D%C3%A9co%2C%20Jardin/2013/1/'>créé le 01/01/2013</a> | <a style="color:black;text-decoration:underline;" href="https://www.canalblog.com/cf/contactAuthor.cfm?mid=100551&amp;bid=1079270" onclick="javascript:window.open(this.href);return false;" rel="nofollow">Contacter l'auteur</a> | <a style="color:black;text-decoration:underline;" href="https://www.canalblog.com/cf/contact.cfm?bid=1079270" onclick="javascript:window.open(this.href);return false;">Signaler un abus</a></div><script type="text/javascript">
+<!--
+var _eStat_Whap_loaded=0;
+//-->
+</script>
+<script type="text/javascript" src="https://w.estat.com/js/whap.js"></script>
+<script type="text/javascript">
+<!--
+if(_eStat_Whap_loaded){
+eStatWhap.serial("800000207013");
+eStatWhap.send();}
+//-->
+</script>
+<script type="text/javascript" src="//static.criteo.net/js/ld/ld.js" async="true"></script>
+<script type="text/javascript">
+window.criteo_q = window.criteo_q || [];
+window.criteo_q.push(
+{ event: "setAccount", account: 5208 },
+{ event: "setCustomerId", id: "" },
+{ event: "setSiteType", type: "d" },
+{ event: "viewHome", user_segment: 1 }
+);
+</script>
+<script type="text/javascript">
+var xl8_script = document.createElement("script");
+xl8_script.src = "http://loadeu.exelator.com/load/?p=527&g=001&j=d&ctg=bricolagedecojardin";
+xl8_script.type = "text/javascript";
+xl8_script.async = true;
+document.body.appendChild(xl8_script);
+</script>
+<script type="text/javascript">
+window._taboola = window._taboola || [];
+_taboola.push({flush: true});
+</script>
+<div id="div-gpt-ad-85649">
+</div>
+<div id="div-gpt-ad-70371">
+</div>
+<div id="div-gpt-ad-95650">
+</div>
+<script type="text/javascript">
+twttr.ready(function (twttr) {
+twttr.events.bind('tweet', function(event) {
+if (event) {
+var targetUrl;
+if (event.target && event.target.nodeName == 'IFRAME') {
+targetUrl = extractParamFromUri(event.target.src, 'url');
+}
+_gaq.push(['_trackSocial', 'twitter', 'tweet', targetUrl]);
+$.get(CBVARS.URLROOT+'/cf/fe/remote/updatesharequeue.cfm?t=twitter&bid='+CBVARS.blog_id+'&u='+encodeURIComponent(targetUrl));
+}
+});
+});
+$(document).ready(function() {
+$.getScript('http://assets.pinterest.com/js/pinit.js', function() {
+// Nothing
+});
+});
+$(document).ready(function() {
+$.getScript('http:////platform.linkedin.com/in.js', function() {
+// Nothing
+});
+});
+$(document).ready(function() {
+$.getScript('https://d1xnn692s7u6t6.cloudfront.net/widget.js', function() {
+// Nothing
+});
+(function k(){window.$SendToKindle&&window.$SendToKindle.Widget?$SendToKindle.Widget.init({"content":".item_div","exclude":".relatedlinks,.itemfooter","title":".articletitle","author":".articlecreator","published":".articledate"}):setTimeout(k,500);})();
+});
+</script>
+<script type='text/javascript' src='/sharedDocs/js/ads.js'></script>
+<script type='text/javascript'>
+if(document.getElementById('OoqBWgJyUzcQ')){
+dataLayer.push({'event': 'sendGAAdblockerEvent','AdBlocker': 'noblock'});
+} else {
+dataLayer.push({'event': 'sendGAAdblockerEvent','AdBlocker': 'adblock'});
+}
+</script>
+</body>
+</html>

--- a/tests/test-01-init.php
+++ b/tests/test-01-init.php
@@ -69,7 +69,7 @@ class ImportInit extends WP_UnitTestCase {
   }
 
   function testGetRemoteHtml () {
-    $body = $this->operation->getRemoteHtml('http://www.miaam.canalblog.com/archives/2010/05/p0-0.html');
+    $body = $this->operation->getRemoteHtml('https://httpstat.us/200');
     $this->assertNotEmpty($body);
 
     try {

--- a/tests/test-05-post.php
+++ b/tests/test-05-post.php
@@ -13,6 +13,10 @@ class ImportPort extends WP_UnitTestCase {
 	  $this->operation->setUri('http://maflo.canalblog.com/archives/2010/09/07/18732506.html');
   }
 
+  public static function setUpBeforeClass() {
+    // array_map('unlink', glob(wp_upload_dir()->basedir . '/**/*'));
+  }
+
   /*
    getContentFromUri()
    */
@@ -39,6 +43,7 @@ class ImportPort extends WP_UnitTestCase {
       // h3
       array('maflo', 'personne ne veut de mes places de cinéma à gagner ????'),
       // bookmark title
+      array('grisfluo', 'Que rapporter de Lisbonne ?'),
       array('couturejulie', 'Je déménage...'),
       array('masbou', 'Nouvelles fraîches'),
       // next h1/h3 after <a name>
@@ -64,6 +69,7 @@ class ImportPort extends WP_UnitTestCase {
       array('masbou', array()),
       array('evacuisine', array('http://www.evacuisine.fr/archives/2009/02/28/12603374-p50-0.html#comments')),
       array('boiremanger', array()),
+      array('grisfluo', array()),
     );
   }
 
@@ -103,6 +109,7 @@ class ImportPort extends WP_UnitTestCase {
 	    array('maflo', '2010-09-07 13:41'),
 	    array('masbou', '2014-07-15 09:54'),
 	    array('evacuisine', '2009-02-28 11:10'),
+      array('grisfluo', '2015-12-08 16:00'),
 	  );
 	}
 
@@ -124,6 +131,7 @@ class ImportPort extends WP_UnitTestCase {
 	    array('maflo', 'maflo'),
 	    array('masbou', 'Olivier Masbou'),
 	    array('evacuisine', 'admin'),
+      array('grisfluo', 'gris fluo & green'),
 	  );
 	}
 
@@ -148,6 +156,7 @@ class ImportPort extends WP_UnitTestCase {
 	    array('maflo', "ou y'a vraiment plus personne qui attérit sur mon blog????", "Allez à vos méninges et rdv le 18 septembre!"),
 	    array('masbou', "Augmentation des surfaces de pommes de terre en Europe", "atteint 355 millions d’euros."),
 	    array('evacuisine', "Aujourd'hui, voici une délicieuse recette de moelleux au citron !", "Bonne journée, et à bientôt avec pleins de nouvelles recettes !"),
+	    array('grisfluo', "Comment rentrer de Lisbonne sans rapporter quelques boîtes de sardines, maquereaux et autres poissons. Nous avons testé deux adresses."),
 	  );
 	}
 
@@ -199,6 +208,13 @@ class ImportPort extends WP_UnitTestCase {
 	      'comment_content' => "y'a pas mieux comme présentation, tu en as de l'imagination! et le citron, j'aime tellement",
 	      'comment_author_url' => 'http://missnature.canalblog.com',
 	    )),
+      array('grisfluo', 2, array(
+	      '__comment_id' => '68343531',
+	      'comment_author' => "gris fluo",
+	      'comment_date' => '2016-01-19 23:09:02',
+	      'comment_content' => "Elles bonifient avec le temps .... Il suffit de les tourner de temps à autre ....",
+	      'comment_author_url' => 'http://grisfluo.canalblog.com',
+	    )),
 	  );
 	}
 
@@ -227,7 +243,8 @@ class ImportPort extends WP_UnitTestCase {
 	    array('couturejulie', 'http://lacouturedejulie.canalblog.com/archives/2013/01/02/26050095.html', 'Je déménage...', 0),
 	    array('maflo', 'http://maflo.canalblog.com/archives/2010/09/07/18732506.html', 'personne ne veut de mes places de cinéma à gagner ????', 24),
 	    array('masbou', 'http://www.leblognotesdoliviermasbou.info/archives/2014/07/15/30252678.html', 'Nouvelles fraîches', 0),
-	    array('evacuisine', 'http://www.evacuisine.fr/archives/2009/02/28/12603374.html', 'Moelleux au citron dans un citron', 69),
+	    // array('evacuisine', 'http://www.evacuisine.fr/archives/2009/02/28/12603374.html', 'Moelleux au citron dans un citron', 69),
+      array('grisfluo', 'http://grisfluo.canalblog.com/archives/2015/12/08/33097920.html', 'Que rapporter de Lisbonne ?', 2),
 	  );
 	}
 
@@ -346,14 +363,14 @@ class ImportPort extends WP_UnitTestCase {
    * @depends testSavePost
    * @group content
    */
-	public function testUpdateAttachmentsRemap($attachments, $expectations) {
-    $wpImport = new WP_Import();
-    $wpImport->fetch_attachments = true;
-
-    $wpImport->url_remap = $this->operation->updateAttachmentsRemap($attachments);
-
-    $this->assertEquals($expectations, $wpImport->url_remap);
-	}
+	// public function testUpdateAttachmentsRemap($attachments, $expectations) {
+  //   $wpImport = new WP_Import();
+  //   $wpImport->fetch_attachments = true;
+  //
+  //   $wpImport->url_remap = $this->operation->updateAttachmentsRemap($attachments);
+  //
+  //   $this->assertEquals($expectations, $wpImport->url_remap);
+	// }
 
 
   /**
@@ -366,6 +383,8 @@ class ImportPort extends WP_UnitTestCase {
 	}
 
 	public function updateAttachmentsRemapProvider() {
+    $yearMonthNow = strftime('%Y/%m');
+
 	  return array(
       [
         'attachments' => [
@@ -407,11 +426,11 @@ class ImportPort extends WP_UnitTestCase {
           ],
         ],
         'expectation' => [
-          'http://storage.canalblog.com/09/65/501700/34561690_p.jpg' => 'http://example.org/wp-content/uploads/2019/11/34561690-300x200.jpg',
-          'http://postaisportugal.canalblog.com/images/t-Fond_d_ecran9.jpg' => 'http://example.org/wp-content/uploads/2019/11/Fond_d_ecran9-150x150.jpg',
-          'http://storage.canalblog.com/09/65/501700/34561690_q.jpg' => 'http://example.org/wp-content/uploads/2019/11/34561690-150x150.jpg',
-          'http://storage.canalblog.com/09/65/501700/34561690.jpg' => 'http://example.org/wp-content/uploads/2019/11/34561690.jpg',
-          'http://p7.storage.canalblog.com/79/42/1295810/98533741.to_resize_150x3000.jpg' => 'http://example.org/wp-content/uploads/2019/11/98533741.jpg',
+          'http://storage.canalblog.com/09/65/501700/34561690_p.jpg' => 'http://example.org/wp-content/uploads/'. $yearMonthNow .'/34561690-300x200.jpg',
+          'http://postaisportugal.canalblog.com/images/t-Fond_d_ecran9.jpg' => 'http://example.org/wp-content/uploads/'. $yearMonthNow .'/Fond_d_ecran9-150x150.jpg',
+          'http://storage.canalblog.com/09/65/501700/34561690_q.jpg' => 'http://example.org/wp-content/uploads/'. $yearMonthNow .'/34561690-150x150.jpg',
+          'http://storage.canalblog.com/09/65/501700/34561690.jpg' => 'http://example.org/wp-content/uploads/'. $yearMonthNow .'/34561690.jpg',
+          'http://p7.storage.canalblog.com/79/42/1295810/98533741.to_resize_150x3000.jpg' => 'http://example.org/wp-content/uploads/'. $yearMonthNow .'/98533741.jpg',
           'http://storage.canalblog.com/65/79/829482/64555901.pdf' => NULL,
         ]
       ]

--- a/tests/test-05-post.php
+++ b/tests/test-05-post.php
@@ -1,5 +1,8 @@
 <?php
 
+include ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+include ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+
 class ImportPort extends WP_UnitTestCase {
 
   protected $importer;
@@ -13,8 +16,15 @@ class ImportPort extends WP_UnitTestCase {
 	  $this->operation->setUri('http://maflo.canalblog.com/archives/2010/09/07/18732506.html');
   }
 
+  /**
+   * WordPress will number assets uploads with the same filename
+   * So we cleanup assets to avoid failures, due to multiple runs
+   */
   public static function setUpBeforeClass() {
-    // array_map('unlink', glob(wp_upload_dir()->basedir . '/**/*'));
+    $fs = new WP_Filesystem_Direct(array());
+
+    $fs->delete(wp_upload_dir()['basedir'], true);
+    $fs->mkdir(wp_upload_dir()['basedir'], true);
   }
 
   /*
@@ -361,27 +371,26 @@ class ImportPort extends WP_UnitTestCase {
 	}
 
   /**
-   * @dataProvider updateAttachmentsRemapProvider
-   * @depends testSavePost
-   * @group content
-   */
-	// public function testUpdateAttachmentsRemap($attachments, $expectations) {
-  //   $wpImport = new WP_Import();
-  //   $wpImport->fetch_attachments = true;
-  //
-  //   $wpImport->url_remap = $this->operation->updateAttachmentsRemap($attachments);
-  //
-  //   $this->assertEquals($expectations, $wpImport->url_remap);
-	// }
-
-
-  /**
    * @depends testSavePost
    */
 	public function testUpdateAttachmentsRemapWithEmptydata() {
     $result = $this->operation->updateAttachmentsRemap(array());
 
     $this->assertEmpty($result);
+	}
+
+  /**
+   * @dataProvider updateAttachmentsRemapProvider
+   * @depends testSavePost
+   * @group content
+   */
+	public function testUpdateAttachmentsRemap($attachments, $expectations) {
+    $wpImport = new WP_Import();
+    $wpImport->fetch_attachments = true;
+
+    $wpImport->url_remap = $this->operation->updateAttachmentsRemap($attachments);
+
+    $this->assertEquals($expectations, $wpImport->url_remap);
 	}
 
 	public function updateAttachmentsRemapProvider() {

--- a/tests/test-05-post.php
+++ b/tests/test-05-post.php
@@ -1,7 +1,7 @@
 <?php
 
-include ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
-include ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+// include ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+// include ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 
 class ImportPort extends WP_UnitTestCase {
 
@@ -20,12 +20,12 @@ class ImportPort extends WP_UnitTestCase {
    * WordPress will number assets uploads with the same filename
    * So we cleanup assets to avoid failures, due to multiple runs
    */
-  public static function setUpBeforeClass() {
-    $fs = new WP_Filesystem_Direct(array());
-
-    $fs->delete(wp_upload_dir()['basedir'], true);
-    $fs->mkdir(wp_upload_dir()['basedir'], true);
-  }
+  // public static function setUpBeforeClass() {
+  //   $fs = new WP_Filesystem_Direct(array());
+  //
+  //   $fs->delete(wp_upload_dir()['basedir'], true);
+  //   wp_mkdir_p(wp_upload_dir()['basedir']);
+  // }
 
   /*
    getContentFromUri()

--- a/tests/test-05-post.php
+++ b/tests/test-05-post.php
@@ -131,12 +131,13 @@ class ImportPort extends WP_UnitTestCase {
 	    array('maflo', 'maflo'),
 	    array('masbou', 'Olivier Masbou'),
 	    array('evacuisine', 'admin'),
-      array('grisfluo', 'gris fluo & green'),
+      array('grisfluo', 'gris fluo'),
 	  );
 	}
 
 	/**
 	 * @dataProvider extractPostContentProvider
+	 * @group content
 	 */
 	public function testExtractPostContent($contentId, $startsWith, $endsWith) {
     $html = file_get_contents(dirname(__FILE__) . '/fixtures/post-'. $contentId .'.html');
@@ -156,7 +157,7 @@ class ImportPort extends WP_UnitTestCase {
 	    array('maflo', "ou y'a vraiment plus personne qui attérit sur mon blog????", "Allez à vos méninges et rdv le 18 septembre!"),
 	    array('masbou', "Augmentation des surfaces de pommes de terre en Europe", "atteint 355 millions d’euros."),
 	    array('evacuisine', "Aujourd'hui, voici une délicieuse recette de moelleux au citron !", "Bonne journée, et à bientôt avec pleins de nouvelles recettes !"),
-	    array('grisfluo', "Comment rentrer de Lisbonne sans rapporter quelques boîtes de sardines, maquereaux et autres poissons. Nous avons testé deux adresses."),
+	    array('grisfluo', "Comment rentrer de Lisbonne sans rapporter quelques boîtes de sardines, maquereaux et autres poissons.", "Le petit moins, lorsque nous y sommes allés, l'accueil a été très moyen, c'était peut être un jour \"sans\"! \n\nI"),
 	  );
 	}
 
@@ -209,11 +210,11 @@ class ImportPort extends WP_UnitTestCase {
 	      'comment_author_url' => 'http://missnature.canalblog.com',
 	    )),
       array('grisfluo', 2, array(
-	      '__comment_id' => '68343531',
-	      'comment_author' => "gris fluo",
-	      'comment_date' => '2016-01-19 23:09:02',
-	      'comment_content' => "Elles bonifient avec le temps .... Il suffit de les tourner de temps à autre ....",
-	      'comment_author_url' => 'http://grisfluo.canalblog.com',
+	      '__comment_id' => '68343351',
+	      'comment_author' => "Fée des Brumes",
+	      'comment_date' => '2016-01-19 22:46:28',
+	      'comment_content' => "Je crois qu'il me reste une boite de mon dernier WE à Lisbonne il y a … deux ans !",
+	      'comment_author_url' => 'http://www.feedesbrumes.com/',
 	    )),
 	  );
 	}
@@ -231,6 +232,7 @@ class ImportPort extends WP_UnitTestCase {
 	  $result = $this->operation->savePost($dom, $html);
 	  $comments = $this->operation->savePaginatedComments($dom, $html);
 
+    $this->assertEquals($result['status'], 'imported');
 	  $this->assertInternalType('integer', $result['id']);
 	  $this->assertEquals('imported', $result['status']);
 	  $this->assertEquals($title, $result['title']);


### PR DESCRIPTION
Visiblement, ça se produit sur toute version de WordPress. C'est peut-être/peut-être pas lié à la version de PHP.

À vue de nez, je dirais que cela se produit lorsqu'il n'y a pas de media, ou quelque chose que je considérais comme toujours présent lors de l'import d'articles.

```
2020/04/03 11:04:36 [error] 19647#19647: *230814 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: Argument 1 passed to CanalblogImporterImporterPost::saveMedias() must be of the type array, null given, called in [redacted]/lib/Importer/Post.class.php on line 96 and defined in [redacted]/lib/Importer/Post.class.php:620
Stack trace:
#0 [redacted]/lib/Importer/Post.class.php(96):CanalblogImporterImporterPost->saveMedias(NULL)
#1 [redacted]/lib/Importer/Posts.class.php(58): CanalblogImporterImporterPost->process()
#2 [redacted]/lib/Plugin.class.php(97): CanalblogImporterImporterPosts->processRemote(Object(WP_Ajax_Response))
#3 [redacted]/wp-includes/class-wp-hook.php(286): CanalblogImporterPlugin->processRemoteOperation('')
#4 /data/nginx" while reading response header from upstream, client: 82.64.126.138, server: [redacted], request: "POST /wp-admin/admin-ajax.php HTTP/2.0", upstream: "fastcgi://unix:/run/php/php7.3-fpm.sock:", host: "[redacted]", referrer: "https://[redacted]/wp-admin/admin.php?import=canalblog"
```

Ça donne ça quand le débug n'est pas activé :

![image](https://user-images.githubusercontent.com/138627/81495568-75b6c380-92b1-11ea-8c7d-9b094e79cdad.png)
